### PR TITLE
fix: add write permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
 env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build-artifacts:
     name: Build ${{ matrix.os }}

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -11,6 +11,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   update-version:
     name: Update Project Version


### PR DESCRIPTION
- Add contents:write permission to version-update workflow to fix push failures
- Add contents:write and packages:write permissions to release workflow
- Fixes 403 permission errors when creating releases and pushing commits

These workflows need explicit write permissions since GitHub Actions defaults to read-only access for GITHUB_TOKEN.

This pull request updates GitHub Actions workflow configuration to explicitly set permissions required for certain jobs to run successfully. The main focus is on ensuring that the workflows have the necessary write access to contents and packages.

**Workflow permissions adjustments:**

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R18-R21): Added `contents: write` and `packages: write` permissions to allow the workflow to publish releases and manage packages.
* [`.github/workflows/version-update.yml`](diffhunk://#diff-3b9e6af6c59b5ee7e732a6427df7a69ffaeab3db2a1427779532d4cd21044728R14-R16): Added `contents: write` permission to enable version update jobs to push changes to the repository.